### PR TITLE
feat: add option to set -e with environment variable PDM_MULTIRUN_USE_VENVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ pdm multirun -ei 3.10,3.11 pytest tests/
 pdm multirun -ei tests38,tests39 pytest tests/
 ```
 
+You can set PDM Multirun to use virtual environments by default by
+setting the `PDM_MULTIRUN_USE_VENVS` environment variable to `1`.
+
 By default, PDM Multirun reads Python versions (or venv names)
 from the `PDM_MULTIRUN_VERSIONS` environment variable.
 It is a string of `{major}.{minor}` versions (or venv names),

--- a/src/pdm_multirun/plugin.py
+++ b/src/pdm_multirun/plugin.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from pdm.core import Core
 
 PYTHON_VERSIONS = os.getenv("PDM_MULTIRUN_VERSIONS", "").split() or [f"3.{minor}" for minor in range(8, 13)]
+USE_VENVS = os.getenv("PDM_MULTIRUN_USE_VENVS", "") == "1"
 
 
 def _comma_separated_list(value: str) -> list[str]:
@@ -47,7 +48,7 @@ class MultirunCommand(RunCommand):
             "-e",
             "--venvs",
             action="store_true",
-            default=False,
+            default=USE_VENVS,
             help="Use virtual environments",
         )
 


### PR DESCRIPTION
As discussed in [Issue 28](https://github.com/namespace/project/issues/10). Have chosen to require the value `1`, matching the value set by the tool itself when running code.

I realise there are no tests in this PR, but it seems the test suite doesn't have unit tests for features like this currently so didn't want to go outside the scope of the issue and start setting them up.