### PR TITLE
chore: drop current silent support for python<3.8 in dev

### DIFF
--- a/duties.py
+++ b/duties.py
@@ -4,17 +4,12 @@ from __future__ import annotations
 
 import os
 import sys
+from importlib.metadata import version as pkgversion
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from duty import duty
 from duty.callables import black, blacken_docs, coverage, lazy, mkdocs, mypy, pytest, ruff, safety
-
-if sys.version_info < (3, 8):
-    from importlib_metadata import version as pkgversion
-else:
-    from importlib.metadata import version as pkgversion
-
 
 if TYPE_CHECKING:
     from duty.context import Context

--- a/scripts/gen_credits.py
+++ b/scripts/gen_credits.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-import sys
+from importlib.metadata import PackageNotFoundError, metadata
 from itertools import chain
 from pathlib import Path
 from textwrap import dedent
@@ -12,11 +12,6 @@ from typing import Mapping, cast
 import toml
 from jinja2 import StrictUndefined
 from jinja2.sandbox import SandboxedEnvironment
-
-if sys.version_info < (3, 8):
-    from importlib_metadata import PackageNotFoundError, metadata
-else:
-    from importlib.metadata import PackageNotFoundError, metadata
 
 project_dir = Path(".")
 pyproject = toml.load(project_dir / "pyproject.toml")


### PR DESCRIPTION
The current version requirement for python for the project is `>=3.8`, yet in some files used for development in the repo (via duty etc.), currently have a version-gated block that supports importing `importlib.metadata` using hte pre-3.8 name `importlib_metadata`.

This PR removes this gate and just imports it using the new style.

I did consider just using a comment to [ignore the UP036](https://docs.astral.sh/ruff/rules/outdated-version-block/) warning that gets raised, but thought that this is a better solution since: a) a user shouldn't be able to install this package / plugin with 3.7 anyway, and b) a developer working on this repo is much more likely to be using a modern version of python, rather than 3.7 which is past end-of-life.